### PR TITLE
checkpoint: create checkpoint file with 0600 instead of 0644

### DIFF
--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -233,8 +233,7 @@ int checkpoint_save(const char *pathname, int dir, const char *user, const char 
 	unsigned int i, nr_paths, nr_chunks;
 	int fd, ret;
 
-	fd = open(pathname, O_WRONLY | O_CREAT | O_TRUNC,
-		  S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
+	fd = open(pathname, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
 	if (fd < 0) {
 		priv_set_errv("open: %s: %s", pathname, strerrno());
 		return -1;


### PR DESCRIPTION
checkpoint_save() opens the checkpoint file with group and other read permissions (0644). The checkpoint file stores the source and destination paths of files being transferred, so on a shared system other local users can read it and learn what files someone is copying. There's no reason for anyone but the owner to read this file, so restrict it to 0600.