### PR TITLE
main: wipe SSH password/passphrase from environment memory

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -484,18 +484,7 @@ int main(int argc, char **argv)
 	if (quiet)
 		to_dev_null(STDOUT_FILENO);
 
-	/* Snapshot password/passphrase from the environment, then wipe
-	 * them in place. getenv() returns a pointer directly into the
-	 * process's original environment block, which stays readable by
-	 * any local process with the same uid via /proc/PID/environ for
-	 * as long as the bytes remain unmodified -- calling unsetenv()
-	 * alone does NOT clear this, since /proc/PID/environ reflects
-	 * the raw exec-time memory, not libc's environ[] bookkeeping.
-	 * Copy the value to the heap, then memset the original bytes to
-	 * remove them from that memory, keeping non-interactive usage
-	 * (scripts, CI) working without leaving the secret exposed for
-	 * the remaining lifetime of the process.
-	 */
+	/* Preserve credentials while removing them from the environment. */
 	s.password = getenv(ENV_SSH_AUTH_PASSWORD);
 	s.passphrase = getenv(ENV_SSH_AUTH_PASSPHRASE);
 	if (s.password) {

--- a/src/main.c
+++ b/src/main.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <string.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <limits.h>
@@ -483,8 +484,32 @@ int main(int argc, char **argv)
 	if (quiet)
 		to_dev_null(STDOUT_FILENO);
 
+	/* Snapshot password/passphrase from the environment, then wipe
+	 * them in place. getenv() returns a pointer directly into the
+	 * process's original environment block, which stays readable by
+	 * any local process with the same uid via /proc/PID/environ for
+	 * as long as the bytes remain unmodified -- calling unsetenv()
+	 * alone does NOT clear this, since /proc/PID/environ reflects
+	 * the raw exec-time memory, not libc's environ[] bookkeeping.
+	 * Copy the value to the heap, then memset the original bytes to
+	 * remove them from that memory, keeping non-interactive usage
+	 * (scripts, CI) working without leaving the secret exposed for
+	 * the remaining lifetime of the process.
+	 */
 	s.password = getenv(ENV_SSH_AUTH_PASSWORD);
 	s.passphrase = getenv(ENV_SSH_AUTH_PASSPHRASE);
+	if (s.password) {
+		char *p = s.password;
+		s.password = strdup(p);
+		memset(p, 0, strlen(p));
+	}
+	if (s.passphrase) {
+		char *p = s.passphrase;
+		s.passphrase = strdup(p);
+		memset(p, 0, strlen(p));
+	}
+	unsetenv(ENV_SSH_AUTH_PASSWORD);
+	unsetenv(ENV_SSH_AUTH_PASSPHRASE);
 
 	if ((m = mscp_init(&o, &s)) == NULL) {
 		pr_err("mscp_init: %s", priv_get_err());


### PR DESCRIPTION
mscp reads MSCP_SSH_AUTH_PASSWORD and MSCP_SSH_AUTH_PASSPHRASE with getenv() and keeps using that pointer for the life of the process. On Linux, /proc/PID/environ exposes the original environment block to any process running as the same user, so the secret stays readable there the whole time mscp is running.

Just calling unsetenv() doesn't fix this, I checked: /proc/PID/environ reflects the raw memory the kernel set up at exec time, not libc's environ[] array that unsetenv() updates. The fix has to overwrite the actual bytes.

This copies the value with strdup() and then memsets the original bytes to zero, plus calls unsetenv() for good measure. Scripts and CI that set these env vars keep working exactly the same; the only difference is the secret no longer lingers in /proc/PID/environ. Verified this end to end against a local sshd: mid-transfer, /proc/<pid>/environ shows MSCP_SSH_AUTH_PASSPHRASE= with an empty value instead of the passphrase.